### PR TITLE
Update github.dev.user.js

### DIFF
--- a/github.dev.user.js
+++ b/github.dev.user.js
@@ -18,7 +18,7 @@
 
     // Link image
     var img = document.createElement("img");
-    img.src = "https://www.google.com/s2/favicons?domain=code.visualstudio.com";
+    img.src = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABHNCSVQICAgIfAhkiAAAAh1JREFUOI2Nk01IVFEUx3/3vnnzXtkHFmIFJn0XmQgFQbsWtiiQwF1Qi4QWbsIQoVTCUFtZiygQChfRKiiEQmp2RZLRF+RARLUxECGcUMb3Me/e0+LppBg1B87iHO7/8jv/w4FKo+Npu9/3Mtg7FuZrHhXPLbVVReKu3CBrvcvMzrH/ZDMoTRKGU3OJ6c9UIL7LGq+NUgxikcQiJkZrp25jhmENQPubLX8XPxvFy7YRh2AtCCAgFiQxIKAZmhyhsXaaG/nXK8SdY69wsy3EAVgB5UCp9E1ElT/CgEapswRFcDJHGZqc5a3ApSefcN1jxGH60MlAFOYYbt0taMRKmiJofgbNGGtIDKCqefFZcLwGFhZSj62Fufkehk6dAMDyh8AubaFDPLblp0FVIxa0hl8FmJ35wZ3WuuWT7Xkci43Dcp2aeFMJ379AtIicGNhQDfX7VvkqdpHCLhGceXCcmnU5lHYIY9haD74PxqQkIhDYHq41DQDsehiJlJYTbK7KpRYrcJ0CV48o4iSPdlMSK1Dl9dP34XmKsJJAUzL3cTyI4wlund4EQG9TA2E0jpMFYyGKwM020zXxVZIEEcqZmthwpZbJwZlVA/e+H8X3W0iitF5I2HnoAGJMWqtKbqH73T18/zxJDMWIHY0HEWtBabBmcQv/ioHDbRSD66hM6rrSqIyHNXaqENkL/9WX4+J4u9v9Mdg+Mp9ff7tQPuffyOD5ICvN+/cAAAAASUVORK5CYII=";
     img.alt = "GOTO VS Code (github.dev)";
 
     var link = document.createElement("a");


### PR DESCRIPTION
由于浏览器CSP限制，无法加载https://www.google.com/s2/favicons?domain=code.visualstudio.com
所以将src转化为dataUrl，望采纳~！